### PR TITLE
Fixes dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ You can also get the pinout at the IEx prompt by using the
 
 ## Schematics and datasheets
 
-* [Schematics](https://mangopi.cc/_media/mq-pro-sch-v12.pdf)
-* [IBOM](https://mangopi.cc/_media/mq-pro-v12-ibom.html) - Interactive web page
+* [Schematics](https://mangopi.org/_media/mq-pro-sch-v12.pdf)
+* [IBOM](https://mangopi.org/_media/mq-pro-v12-ibom.html) - Interactive web page
   to help you find what part is located where
-* [D1 documentation](https://github.com/mangopi-sbc/MQ-Pro/tree/main/3.Docs)
+* [D1 user manual (PDF, 1390 pages)](https://mangopi.org/_media/d1-h_user_manual_v1.0.pdf)
 
 ## Thanks
 


### PR DESCRIPTION
Hello,
The domain used by mangopi.cc now gives an HTTPs error. The docs are now on mangopi.org.
The github repo linked for the D1 doc disappeared, I linked Allwinner's D1 PDF manual instead.
Have a nice day !