### PR TITLE
fwup: Consolodate duplicate metadata into fwup_include/fwup-common.conf

### DIFF
--- a/fwup-ops.conf
+++ b/fwup-ops.conf
@@ -16,74 +16,10 @@
 #    build process. The file is stored in `/usr/share/fwup/ops.fw`.
 # 2. On the device, run `fwup -t <task> -d /dev/rootdisk0 --enable-trim /usr/share/fwup/ops.fw`.
 # 3. Reboot after running `revert` or `factory-reset`.
-#
-# It is critical that this is kept in sync with the main fwup.conf.
 
 require-fwup-version="1.0.0"
 
-#
-# Firmware metadata
-#
-
-# All of these can be overriden using environment variables of the same name.
-#
-#  Run 'fwup -m' to query values in a .fw file.
-#  Use 'fw_printenv' to query values on the target.
-#
-# These are used by Nerves libraries to introspect.
-define(NERVES_FW_PRODUCT, "Nerves Firmware")
-define(NERVES_FW_DESCRIPTION, "")
-define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
-define(NERVES_FW_PLATFORM, "mangopi_mq_pro")
-define(NERVES_FW_ARCHITECTURE, "riscv")
-define(NERVES_FW_AUTHOR, "The Nerves Team")
-
-# This configuration file will create an image that
-# has an MBR and the following layout:
-#
-# +----------------------------+
-# | MBR                        |
-# +----------------------------+
-# | SPL and U-Boot             |
-# +----------------------------+
-# | U-Boot environment         |
-# +----------------------------+
-# | p1: Rootfs A (squashfs)    |
-# +----------------------------+
-# | p2: Rootfs B (squashfs)    |
-# +----------------------------+
-# | p3: Application (f2fs)     |
-# +----------------------------+
-
-define(UBOOT_OFFSET, 16)
-define(UBOOT_COUNT, 8176)
-
-# The U-Boot environment is written directly to the SDCard/eMMC. It is not
-# in any partition
-define(UBOOT_ENV_OFFSET, 8192)
-define(UBOOT_ENV_COUNT, 256)  # 128 KB
-
-# Let the rootfs have room to grow up to 140 MiB and align it to the nearest 1
-# MB boundary
-define(ROOTFS_A_PART_OFFSET, 43008)
-define(ROOTFS_A_PART_COUNT, 286720)
-define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
-define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
-
-# Application partition. This partition can occupy all of the remaining space.
-# Size it to fit the destination.
-define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
-define(APP_PART_COUNT, 1048576)
-
-# Firmware archive metadata
-meta-product = ${NERVES_FW_PRODUCT}
-meta-description = ${NERVES_FW_DESCRIPTION}
-meta-version = ${NERVES_FW_VERSION}
-meta-platform = ${NERVES_FW_PLATFORM}
-meta-architecture = ${NERVES_FW_ARCHITECTURE}
-meta-author = ${NERVES_FW_AUTHOR}
-meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
-meta-misc = ${NERVES_FW_MISC}
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
 # Location where installed firmware information is stored.
 uboot-environment uboot-env {

--- a/fwup.conf
+++ b/fwup.conf
@@ -2,78 +2,7 @@
 
 require-fwup-version="1.0.0"
 
-#
-# Firmware metadata
-#
-
-# All of these can be overriden using environment variables of the same name.
-#
-#  Run 'fwup -m' to query values in a .fw file.
-#  Use 'fw_printenv' to query values on the target.
-#
-# These are used by Nerves libraries to introspect.
-define(NERVES_FW_PRODUCT, "Nerves Firmware")
-define(NERVES_FW_DESCRIPTION, "")
-define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
-define(NERVES_FW_PLATFORM, "mangopi_mq_pro")
-define(NERVES_FW_ARCHITECTURE, "riscv")
-define(NERVES_FW_AUTHOR, "The Nerves Team")
-
-define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
-define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
-define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
-define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
-define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
-
-# Default paths if not specified via the commandline
-define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
-
-# This configuration file will create an image that
-# has an MBR and the following layout:
-#
-# +----------------------------+
-# | MBR                        |
-# +----------------------------+
-# | SPL and U-Boot             |
-# +----------------------------+
-# | U-Boot environment         |
-# +----------------------------+
-# | p1: Rootfs A (squashfs)    |
-# +----------------------------+
-# | p2: Rootfs B (squashfs)    |
-# +----------------------------+
-# | p3: Application (f2fs)     |
-# +----------------------------+
-
-define(UBOOT_OFFSET, 16)
-define(UBOOT_COUNT, 8176)
-
-# The U-Boot environment is written directly to the SDCard/eMMC. It is not
-# in any partition
-define(UBOOT_ENV_OFFSET, 8192)
-define(UBOOT_ENV_COUNT, 256)  # 128 KB
-
-# Let the rootfs have room to grow up to 140 MiB and align it to the nearest 1
-# MB boundary
-define(ROOTFS_A_PART_OFFSET, 43008)
-define(ROOTFS_A_PART_COUNT, 286720)
-define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
-define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
-
-# Application partition. This partition can occupy all of the remaining space.
-# Size it to fit the destination.
-define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
-define(APP_PART_COUNT, 1048576)
-
-# Firmware archive metadata
-meta-product = ${NERVES_FW_PRODUCT}
-meta-description = ${NERVES_FW_DESCRIPTION}
-meta-version = ${NERVES_FW_VERSION}
-meta-platform = ${NERVES_FW_PLATFORM}
-meta-architecture = ${NERVES_FW_ARCHITECTURE}
-meta-author = ${NERVES_FW_AUTHOR}
-meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
-meta-misc = ${NERVES_FW_MISC}
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
 # File resources are listed in the order that they are included in the .fw file
 # This is important, since this is the order that they're written on a firmware

--- a/fwup_include/fwup-common.conf
+++ b/fwup_include/fwup-common.conf
@@ -1,0 +1,72 @@
+#
+# Firmware metadata
+#
+
+# All of these can be overriden using environment variables of the same name.
+#
+#  Run 'fwup -m' to query values in a .fw file.
+#  Use 'fw_printenv' to query values on the target.
+#
+# These are used by Nerves libraries to introspect.
+define(NERVES_FW_PRODUCT, "Nerves Firmware")
+define(NERVES_FW_DESCRIPTION, "")
+define(NERVES_FW_VERSION, "${NERVES_SDK_VERSION}")
+define(NERVES_FW_PLATFORM, "mangopi_mq_pro")
+define(NERVES_FW_ARCHITECTURE, "riscv")
+define(NERVES_FW_AUTHOR, "The Nerves Team")
+
+define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
+define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
+define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
+define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
+
+# Default paths if not specified via the commandline
+define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
+
+# This configuration file will create an image that
+# has an MBR and the following layout:
+#
+# +----------------------------+
+# | MBR                        |
+# +----------------------------+
+# | SPL and U-Boot             |
+# +----------------------------+
+# | U-Boot environment         |
+# +----------------------------+
+# | p1: Rootfs A (squashfs)    |
+# +----------------------------+
+# | p2: Rootfs B (squashfs)    |
+# +----------------------------+
+# | p3: Application (f2fs)     |
+# +----------------------------+
+
+define(UBOOT_OFFSET, 16)
+define(UBOOT_COUNT, 8176)
+
+# The U-Boot environment is written directly to the SDCard/eMMC. It is not
+# in any partition
+define(UBOOT_ENV_OFFSET, 8192)
+define(UBOOT_ENV_COUNT, 256)  # 128 KB
+
+# Let the rootfs have room to grow up to 140 MiB and align it to the nearest 1
+# MB boundary
+define(ROOTFS_A_PART_OFFSET, 43008)
+define(ROOTFS_A_PART_COUNT, 286720)
+define-eval(ROOTFS_B_PART_OFFSET, "${ROOTFS_A_PART_OFFSET} + ${ROOTFS_A_PART_COUNT}")
+define(ROOTFS_B_PART_COUNT, ${ROOTFS_A_PART_COUNT})
+
+# Application partition. This partition can occupy all of the remaining space.
+# Size it to fit the destination.
+define-eval(APP_PART_OFFSET, "${ROOTFS_B_PART_OFFSET} + ${ROOTFS_B_PART_COUNT}")
+define(APP_PART_COUNT, 1048576)
+
+# Firmware archive metadata
+meta-product = ${NERVES_FW_PRODUCT}
+meta-description = ${NERVES_FW_DESCRIPTION}
+meta-version = ${NERVES_FW_VERSION}
+meta-platform = ${NERVES_FW_PLATFORM}
+meta-architecture = ${NERVES_FW_ARCHITECTURE}
+meta-author = ${NERVES_FW_AUTHOR}
+meta-vcs-identifier = ${NERVES_FW_VCS_IDENTIFIER}
+meta-misc = ${NERVES_FW_MISC}


### PR DESCRIPTION
There is duplication of a set of defined variables between the fwup.conf and fwup-ops.conf.
This PR eliminate this duplication by putting the common variable definitions into a file: fwup_include/fwup-common.conf and then includes it in fwup.conf and fwup-ops.conf with:
```
include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
```
This allows the file to be found correctly in all the build environments where it is referenced. In one, the ${NERVES_SDK_IMAGES} variable exists and will be used and in the other it doesn't exist and the default value of . works there too
