### PR TITLE
Use long serial numbers by default

### DIFF
--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -1,8 +1,8 @@
 # boardid.config
 
-# Read the D1's SID and use the last 8 digits (turns out 4 isn't sufficient)
+# Read the D1's SID
 # NOTE: I couldn't find good information on how reliable this method was in
 #       producing a unique ID. The SID info in the D1's datasheet was on
 #       accessing the SID and not on how the eFuse's were programmed. Please
 #       let me know if you find definitive info on this.
--b binfile -f /sys/bus/nvmem/devices/sunxi-sid0/nvmem -l 16 -k 0 -n 8
+-b binfile -f /sys/bus/nvmem/devices/sunxi-sid0/nvmem -l 16 -k 0

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -1,4 +1,8 @@
 # Additional configuration for erlinit
+#
+# To override the settings in this file, see
+# https://hexdocs.pm/nerves/advanced-configuration.html#overriding-erlinit-config-from-mix-config.
+#
 
 # Turn on the debug prints
 #-v
@@ -61,10 +65,10 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a hostname of the form "nerves-<serial_number>".
+# Assign a hostname of the form "nerves-<last 8 chars of the serial number>".
 # See /etc/boardid.config for locating the serial number.
 -d /usr/bin/boardid
--n nerves-%s
+-n nerves-%-.8s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the
 # shoehorn OTP release up first. If shoehorn isn't around, erlinit fails back


### PR DESCRIPTION
Serial numbers previously were limited to 4 characters for ease of
typing for new users. Now that they're used more places, they're far too
short.
