### PR TITLE
Turn off RISC-V vector instructions since they don't compile

### DIFF
--- a/nerves_defconfig
+++ b/nerves_defconfig
@@ -5,7 +5,6 @@ BR2_RISCV_ISA_RVA=y
 BR2_RISCV_ISA_RVF=y
 BR2_RISCV_ISA_RVD=y
 BR2_RISCV_ISA_RVC=y
-BR2_RISCV_ISA_RVV=y
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
 BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/nerves-project/toolchains/releases/download/v13.2.0/nerves_toolchain_riscv64_nerves_linux_gnu-linux_${shell uname -m}-13.2.0-DB80D1B.tar.xz"


### PR DESCRIPTION
It appears that RVV support was a lie and we'll have to revisit when we
update toolchains.
